### PR TITLE
Update MysqlQueryRunner.ts

### DIFF
--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -1318,8 +1318,8 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
                         tableColumn.default = `'${dbColumn["COLUMN_DEFAULT"]}'`;
                     }
 
-                    if (dbColumn["EXTRA"].indexOf("on update") !== -1) {
-                        tableColumn.onUpdate = dbColumn["EXTRA"].substring(dbColumn["EXTRA"].indexOf("on update") + 10);
+                    if (dbColumn["EXTRA"].toLowerCase().indexOf("on update") !== -1) {
+                        tableColumn.onUpdate = dbColumn["EXTRA"].substring(dbColumn["EXTRA"].toLowerCase().indexOf("on update") + 10);
                     }
 
                     if (dbColumn["GENERATION_EXPRESSION"]) {


### PR DESCRIPTION
In Mariadb the extra information of a DDL is in upper case and in javascript String.indexOf() function is case sensitive, because of that when you generate a new migrations  in mariadb it always create a line to update  "onUpdate" lines.

 example:
```sql
CREATE TABLE `test` (
  `test_id` int(11) NOT NULL AUTO_INCREMENT,
  `test_update` timestamp() NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
  PRIMARY KEY (`test_id`)
) ENGINE=InnoDB DEFAULT CHARSET=latin1
```

When you try to generate a new migration always create the next migration file:

```ts
import { MigrationInterface, QueryRunner } from 'typeorm';

export class test261600082802966 implements MigrationInterface {
  name = 'test261600082802966';

  public async up(queryRunner: QueryRunner): Promise<void> {
    await queryRunner.query(
      'ALTER TABLE `test` CHANGE `test_update` `test_update` timestamp() NOT NULL DEFAULT CURRENT_TIMESTAMP() ON UPDATE CURRENT_TIMESTAMP()'
    );
  }

  public async down(queryRunner: QueryRunner): Promise<void> {
    await queryRunner.query(
      'ALTER TABLE `test` CHANGE `test_update` `test_update` timestamp() NOT NULL DEFAULT CURRENT_TIMESTAMP() ON UPDATE current_timestamp()'
    );
  }
}
```
Entity file test.ts
```ts
import { BaseEntity, Column, Entity, PrimaryGeneratedColumn } from 'typeorm';

@Entity()
export class test extends BaseEntity {
  @PrimaryGeneratedColumn({})
  test_id: number;

  @Column({
    type: 'timestamp',
    default: () => 'CURRENT_TIMESTAMP()',
    onUpdate: 'CURRENT_TIMESTAMP()',
    nullable: false,
  })
  test_update: Date;
}
```